### PR TITLE
Deleted the log message related to the container described at the top.

### DIFF
--- a/lib/fluent/plugin/in_jvm_gclog.rb
+++ b/lib/fluent/plugin/in_jvm_gclog.rb
@@ -47,6 +47,12 @@ class JVMGCLogInput < TailInput
   end
 
   def receive_lines(lines, tail_watcher = nil)
+    if lines
+      lines.each do |line|
+        line.gsub!(/^.*message:/, '')
+      end
+    end
+
     es = parse_lines(lines)
     unless es.empty?
       tag = if @tag_prefix || @tag_suffix

--- a/lib/fluent/plugin/in_jvm_gclog.rb
+++ b/lib/fluent/plugin/in_jvm_gclog.rb
@@ -49,7 +49,7 @@ class JVMGCLogInput < TailInput
   def receive_lines(lines, tail_watcher = nil)
     if lines
       lines.each do |line|
-        line.gsub!(/^.*message:/, '')
+        line.gsub!(/^.*\t?message:/, '')
       end
     end
 


### PR DESCRIPTION
ログの先頭にコンテナのログが付与される。
in_jvm_gclogでパースする前に`message:`より前を削除したい


### 修正前

```
Aug 15 06:45:26 e9cfc2b2b6f8 env:local	container:digdag-agent	container_id:479f080d2ad5	message:2017-08-15T06:45:26.630+0000: 5243.892: [CMS-concurrent-sweep-start]```
```

### 修正後

```
2017-08-15T06:45:26.630+0000: 5243.892: [CMS-concurrent-sweep-start]message:
```