### PR TITLE
Add container_id

### DIFF
--- a/lib/fluent/plugin/in_jvm_gclog.rb
+++ b/lib/fluent/plugin/in_jvm_gclog.rb
@@ -48,16 +48,12 @@ class JVMGCLogInput < TailInput
   end
 
   def receive_lines(lines, tail_watcher = nil)
-    containers = {}
+    containers = Hash.new {|h,k| h[k] = [] }
     if lines
       lines.each_with_index do |line, i|
         m = line.match(/^.*container_id:([0-9a-z]+)\tmessage:(.+)/)
         if m
-          if containers.has_key?(m[1])
-            containers[m[1]] << m[2]
-          else
-            containers[m[1]] = []
-          end
+          containers[m[1]] << m[2]
         end
       end
     end

--- a/lib/fluent/plugin/in_jvm_gclog.rb
+++ b/lib/fluent/plugin/in_jvm_gclog.rb
@@ -51,7 +51,7 @@ class JVMGCLogInput < TailInput
   def receive_lines(lines, tail_watcher = nil)
     if lines
       lines.each_with_index do |line, i|
-        m = line.match(/^.*container_id:([0-9a-z]+)\t+message:(.+)/)
+        m = line.match(/^.*container_id:([0-9a-z]+)\tmessage:(.+)/)
         if m
           @container_id = m[1]
           lines[i] = m[2]


### PR DESCRIPTION
# 変更内容
コンテナから流れてくるログをパースして、fluentdのJSONにcontainer_idを付与します。

## digdag/gc.log

```
Sep 11 07:27:33 1cab8640a55f digdag_jvm_gc: env:local	container:digdag-agent	container_id:5e1e6a41ddd6	message:2017-09-11T07:27:32.990+0000: 153075.189: [GC (CMS Initial Mark) [1 CMS-initial-mark: 51080K(57536K)] 53371K(76544K), 0.0030717 secs] [Times: user=0.00 sys=0.00, real=0.00 secs] 
```

## fluentd log

### jvm.gclog.CMS-initial-mark

```
2017-09-15 14:40:56 +0900 jvm.gclog.CMS-initial-mark: {"uptime":6632.897,"container_id":"bf28be58435b","old_before":43719,"old_threshold":47744,"heap_before":46044,"heap_total":66752,"gctime":0.0040494,"type":"CMS-initial-mark","gctime_user":0.0,"gctime_sys":0.0,"gctime_real":0.0,"host":"SatoruMikaminoMacBook-Pro"}
```

### CMS-Final-Remark

```
2017-09-15 14:40:56 +0900 jvm.gclog.CMS-Final-Remark: {"uptime":6633.267,"container_id":"bf28be58435b","gctime":0.0637087,"type":"CMS-Final-Remark","gctime_user":0.06,"gctime_sys":0.0,"gctime_real":0.06,"host":"SatoruMikaminoMacBook-Pro"}
```
=> `"container_id":"5e1e6a41ddd6"`が追加されたID